### PR TITLE
Fix yml parsing

### DIFF
--- a/src/DICIT/Config/YML.php
+++ b/src/DICIT/Config/YML.php
@@ -20,24 +20,22 @@ class YML extends AbstractConfig
 
     protected function loadFile($filePath)
     {
-        if (!is_file($filePath)) {
-            throw new \Exception('File not found: ' . $filePath);
-        }
         $yml = array();
         $dirname = dirname($filePath);
-        $yaml = new \Symfony\Component\Yaml\Yaml();
-        $res = $yaml->parse($filePath);
+        $res = Yaml::parse($filePath);
 
-        foreach($res as $key => $value) {
-            if ($key == 'include') {
-                foreach($value as $file) {
-                    $file = preg_replace_callback('`\${env\.([^}]+)}`i', function($matches) { return getenv($matches[1]); }, $file);
-                    $subYml = $this->loadFile($dirname . '/' . $file);
-                    $yml = Arrays::mergeRecursiveUnique($yml, $subYml);
+        if(is_array($res)){
+            foreach($res as $key => $value) {
+                if ($key == 'include') {
+                    foreach($value as $file) {
+                        $file = preg_replace_callback('`\${env\.([^}]+)}`i', function($matches) { return getenv($matches[1]); }, $file);
+                        $subYml = $this->loadFile($dirname . '/' . $file);
+                        $yml = Arrays::mergeRecursiveUnique($yml, $subYml);
+                    }
                 }
-            }
-            else {
-                $yml = Arrays::mergeRecursiveUnique($yml, array($key => $res[$key]));
+                else {
+                    $yml = Arrays::mergeRecursiveUnique($yml, array($key => $res[$key]));
+                }
             }
         }
 


### PR DESCRIPTION
Because of

```
[12:16:54] Warning: gulp version mismatch:
[12:16:54] Global gulp is 3.8.11
[12:16:54] Local gulp is 3.8.10
[12:16:54] Using gulpfile ~/gulpfile.js
[12:16:54] Starting 'build:yml-to-php'...
PHP Warning:  Invalid argument supplied for foreach() in dic-it/src/DICIT/Config/YML.php on line 28
PHP Stack trace:
PHP   1. {main}() tasks-gulp/compile.php:0
PHP   2. DICIT\Config\YML->compile() tasks-gulp/compile.php:46
PHP   3. DICIT\Config\AbstractConfig->load() dic-it/src/DICIT/Config/YML.php:46
PHP   4. DICIT\Config\YML->doLoad() dic-it/src/DICIT/Config/AbstractConfig.php:11
PHP   5. DICIT\Config\YML->loadFile() dic-it/src/DICIT/Config/YML.php:18
PHP   6. DICIT\Config\YML->loadFile() dic-it/src/DICIT/Config/YML.php:32
[12:16:57] Finished 'build:yml-to-php' after 2.12 s
[12:16:57] Starting 'build'...
[12:16:57] Finished 'build' after 16 μs
[12:16:57] Starting 'default'...
[12:16:57] Finished 'default' after 14 μs
```